### PR TITLE
Ament index marker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,14 @@ install(
     "share/darknet"
 )
 
+# Add an entry to the ament index
+install(
+  FILES
+    resource/darknet_vendor
+  DESTINATION
+    "share/ament_index/resource_index/packages/"
+)
+
 # Install license files
 install(
   FILES


### PR DESCRIPTION
This would allow the package to be found using `ros2 pkg list` in a merged workspace, but doesn't work in an isolated workspace because build_type `cmake` doesn't extend `AMENT_PREFIX_PATH`.