### PR TITLE
Fix cuda build downstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if(DARKNET_CUDA)
   endif()
 
   add_library(darknet SHARED ${darknet_lib_c_sources} ${darknet_lib_cpp_sources} ${darknet_cuda_sources})
-  target_compile_options(darknet INTERFACE
+  target_compile_options(darknet PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:${DARKNET_VENDOR_CUDA_FLAGS}>
   )
   target_compile_definitions(darknet PUBLIC GPU=1)

--- a/include/darknet_vendor/darknet_vendor.h
+++ b/include/darknet_vendor/darknet_vendor.h
@@ -15,18 +15,8 @@
 #ifndef DARKNET_VENDOR__DARKNET_VENDOR_H_
 #define DARKNET_VENDOR__DARKNET_VENDOR_H_
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <darknet.h>
 #include <darknet_vendor/version.h>
-
-#ifdef __cplusplus
-}
-#endif
-
 
 #endif  // DARKNET_VENDOR__DARKNET_VENDOR_H_
 


### PR DESCRIPTION
This fixes build failures in `openrobotics_darknet_ros` when building `darknet_vendor` with cuda support. Cuda language flags should not be exported to downstream packages. The darknet header should not be declared with C linkage because it includes C++ cuda headers.